### PR TITLE
Add Ray cluster config

### DIFF
--- a/scripts/config/raysort-cluster.yaml
+++ b/scripts/config/raysort-cluster.yaml
@@ -8,7 +8,7 @@ provider:
 
 auth:
     ssh_user: ubuntu
-    ssh_private_key: ../../login-us-west-2.pem
+    ssh_private_key: ~/.aws/login-us-west-2.pem
 
 available_node_types:
     ray.head.default:


### PR DESCRIPTION
This adds a minimal configuration for the ray autoscaler using the raysort AMI. Full configuration is available at https://docs.ray.io/en/latest/cluster/config.html#full-configuration 

To test, run `ray up -y raysort-cluster.yaml`. To bring down the cluster, run `ray down raysort-cluster.yaml`. This also requires that `login-us-west-2.pem` is located in the `~/.aws` directory.