### PR TITLE
Create autoscaler config based on raysort config name

### DIFF
--- a/scripts/autoscaler.py
+++ b/scripts/autoscaler.py
@@ -23,7 +23,9 @@ def get_or_create_autoscaler_config(raysort_config: str) -> pathlib.Path:
         click.echo(f"Found existing configuration for {raysort_config} config")
         return autoscaler_config_path
 
-    assert not os.path.exists(autoscaler_config_path), f"{autoscaler_config_path} must not exist"
+    assert not os.path.exists(
+        autoscaler_config_path
+    ), f"{autoscaler_config_path} must not exist"
     assert os.path.exists(
         AUTOSCALER_CONFIG_TEMPLATE_PATH
     ), f"{AUTOSCALER_CONFIG_TEMPLATE_PATH} must exist"


### PR DESCRIPTION
Currently the autoscaler script creates copies of the template file based on the `CLUSTER_NAME` environment variable. This PR changes it such that this is based on the raysort `CONFIG` environment variable instead as this makes more sense from a user's perspective.