### PR TITLE
Refactor shuffle_lib

### DIFF
--- a/raysort/tracing_utils.py
+++ b/raysort/tracing_utils.py
@@ -1,5 +1,6 @@
 import collections
 import dataclasses
+import functools
 import json
 import logging
 import os
@@ -66,6 +67,15 @@ class timeit:
             echo=self.report_completed,
         )
         return False
+
+
+def timeit_wrapper(fn: Callable):
+    @functools.wraps(fn)
+    def wrapped_fn(*args, **kwargs):
+        with timeit(fn.__name__):
+            return fn(*args, **kwargs)
+
+    return wrapped_fn
 
 
 def record_value(*args, **kwargs):


### PR DESCRIPTION
Changes:
* Implemented simple shuffle and streaming shuffle in shuffle_lib
* Use pandas to improve word count performance


[map_reduce_start_times_simple.pdf](https://github.com/exoshuffle/raysort/files/9503748/map_reduce_start_times_simple.pdf)
[map_reduce_start_times_streaming_proper.pdf](https://github.com/exoshuffle/raysort/files/9503749/map_reduce_start_times_streaming_proper.pdf)