### PR TITLE
Configs for i4i4x experiments

### DIFF
--- a/raysort/config/aws.py
+++ b/raysort/config/aws.py
@@ -392,25 +392,6 @@ configs = [
         ),
     ),
     # ------------------------------------------------------------
-    #     S3 + larger i4i nodes
-    # ------------------------------------------------------------
-    JobConfig(
-        # 691s, https://wandb.ai/raysort/raysort/runs/jd7mynet
-        name="6tb-2gb-i4i4x-s3",
-        cluster=dict(
-            instance_count=30,
-            instance_type=i4i_4xl,
-        ),
-        system=dict(),
-        app=dict(
-            **get_steps(),
-            total_gb=6000,
-            input_part_gb=2,
-            s3_buckets=get_s3_buckets(),
-            reduce_parallelism_multiplier=1,
-        ),
-    ),
-    # ------------------------------------------------------------
     #     S3 + i4i.2xl 10 nodes
     # ------------------------------------------------------------
     JobConfig(
@@ -435,7 +416,7 @@ configs = [
         # TODO
         name="1tb-2gb-i4i4x-s3",
         cluster=dict(
-            instance_count=5,
+            instance_count=10,
             instance_type=i4i_4xl,
         ),
         system=dict(),
@@ -444,7 +425,9 @@ configs = [
             total_gb=1000,
             input_part_gb=2,
             s3_buckets=get_s3_buckets(),
+            map_parallelism_multiplier=1,
             reduce_parallelism_multiplier=1,
+            merge_factor=1,
         ),
     ),
     # ------------------------------------------------------------
@@ -463,11 +446,13 @@ configs = [
             total_gb=2000,
             input_part_gb=2,
             s3_buckets=get_s3_buckets(),
+            map_parallelism_multiplier=1,
             reduce_parallelism_multiplier=1,
+            merge_factor=1,
         ),
     ),
     JobConfig(
-        # 459s
+        # 402s, https://wandb.ai/raysort/raysort/runs/jpegf7l2
         name="2tb-2gb-i4i4x-s3",
         cluster=dict(
             instance_count=10,
@@ -478,9 +463,47 @@ configs = [
             **get_steps(),
             total_gb=2000,
             input_part_gb=2,
+            # output_part_gb=4,
             s3_buckets=get_s3_buckets(),
-            map_parallelism_multiplier=1,
-            reduce_parallelism_multiplier=1,
+            map_parallelism_multiplier=12 / 16,
+            reduce_parallelism_multiplier=12 / 16,
+            merge_factor=1,
+        ),
+    ),
+    JobConfig(
+        # 1550s
+        name="8tb-2gb-10-i4i4x-s3",
+        cluster=dict(
+            instance_count=10,
+            instance_type=i4i_4xl,
+        ),
+        system=dict(),
+        app=dict(
+            **get_steps(),
+            total_gb=8000,
+            input_part_gb=2,
+            output_part_gb=4,
+            s3_buckets=get_s3_buckets(),
+            map_parallelism_multiplier=0.75,
+            reduce_parallelism_multiplier=0.75,
+            merge_factor=1,
+        ),
+    ),
+    JobConfig(
+        # 433s * 8
+        name="16tb-2gb-i4i4x-s3",
+        cluster=dict(
+            instance_count=10,
+            instance_type=i4i_4xl,
+        ),
+        system=dict(),
+        app=dict(
+            **get_steps(),
+            total_gb=16000,
+            input_part_gb=2,
+            s3_buckets=get_s3_buckets(),
+            map_parallelism_multiplier=0.75,
+            reduce_parallelism_multiplier=0.75,
             merge_factor=1,
         ),
     ),
@@ -504,6 +527,25 @@ configs = [
         ),
     ),
     JobConfig(
+        # 418s, https://wandb.ai/raysort/raysort/runs/3n4runhx
+        name="4tb-2gb-i4i4x-s3",
+        cluster=dict(
+            instance_count=20,
+            instance_type=i4i_4xl,
+        ),
+        system=dict(),
+        app=dict(
+            **get_steps(),
+            total_gb=4000,
+            input_part_gb=2,
+            s3_buckets=get_s3_buckets(),
+            map_parallelism_multiplier=0.75,
+            reduce_parallelism_multiplier=0.75,
+            merge_factor=1,
+            num_shards_per_mapper=2,
+        ),
+    ),
+    JobConfig(
         # 2901s, https://wandb.ai/raysort/raysort/runs/q0w17xxi
         name="20tb-2gb-i4i-native-s3",
         cluster=dict(
@@ -519,37 +561,17 @@ configs = [
             reduce_parallelism_multiplier=1,
         ),
     ),
-    # ------------------------------------------------------------
-    #     S3 + i4i.2xl 60 nodes
-    # ------------------------------------------------------------
     JobConfig(
-        # TODO: need to get this down to 500s?
-        # 575s, https://wandb.ai/raysort/raysort/runs/hfif924k
-        name="6tb-2gb-i4i-native-s3",
+        # 1266s; 1100s if perfect scaling
+        name="10tb-2gb-20-i4i4x-s3",
         cluster=dict(
-            instance_count=60,
-            instance_type=i4i_2xl,
-        ),
-        system=dict(),
-        app=dict(
-            **get_steps(),
-            total_gb=6000,
-            input_part_gb=2,
-            s3_buckets=get_s3_buckets(),
-            reduce_parallelism_multiplier=1,
-        ),
-    ),
-    JobConfig(
-        # 547s (making progress!)
-        name="6tb-2gb-i4i4x-s3",
-        cluster=dict(
-            instance_count=32,
+            instance_count=20,
             instance_type=i4i_4xl,
         ),
         system=dict(),
         app=dict(
             **get_steps(),
-            total_gb=6000,
+            total_gb=10000,
             input_part_gb=2,
             s3_buckets=get_s3_buckets(),
             map_parallelism_multiplier=1,
@@ -557,21 +579,43 @@ configs = [
             merge_factor=1,
         ),
     ),
+    # ------------------------------------------------------------
+    #     S3 + i4i.2xl 60 nodes
+    # ------------------------------------------------------------
     JobConfig(
-        # TODO: need to get this down to 4000s
-        # 4866s, https://wandb.ai/raysort/raysort/runs/3eaxbo33
-        name="48tb-2gb-i4i-native-s3",
+        # 454s, https://wandb.ai/raysort/raysort/runs/3jpwrmic
+        name="6tb-2gb-i4i4x-s3",
         cluster=dict(
-            instance_count=60,
-            instance_type=i4i_2xl,
+            instance_count=30,
+            instance_type=i4i_4xl,
         ),
         system=dict(),
         app=dict(
             **get_steps(),
-            total_gb=48000,
+            total_gb=6000,
             input_part_gb=2,
-            s3_buckets=get_s3_buckets(),
+            s3_buckets=get_s3_buckets(30),
+            map_parallelism_multiplier=0.75,
+            reduce_parallelism_multiplier=0.75,
+            merge_factor=1,
+        ),
+    ),
+    JobConfig(
+        # 5748s with a long tail.
+        name="60tb-2gb-i4i4x-s3",
+        cluster=dict(
+            instance_count=36,
+            instance_type=i4i_4xl,
+        ),
+        system=dict(),
+        app=dict(
+            **get_steps(),
+            total_gb=60000,
+            input_part_gb=2,
+            s3_buckets=get_s3_buckets(20),
+            map_parallelism_multiplier=1,
             reduce_parallelism_multiplier=1,
+            merge_factor=1,
         ),
     ),
     # ------------------------------------------------------------
@@ -613,40 +657,65 @@ configs = [
             reduce_parallelism_multiplier=1,
         ),
     ),
+    # ------------------------------------------------------------
+    #     S3 + i4i.4xl 40 nodes
+    # ------------------------------------------------------------
     JobConfig(
-        # TODO(@lsf)
-        name="100tb-2gb-i4i-native-s3",
+        # 460s, https://wandb.ai/raysort/raysort/runs/17mqvhde
+        # 456s, https://wandb.ai/raysort/raysort/runs/6emlt2u1
+        name="8tb-2gb-i4i4x-s3",
         cluster=dict(
-            instance_count=100,
-            instance_type=i4i_2xl,
+            instance_count=40,
+            instance_type=i4i_4xl,
+        ),
+        system=dict(),
+        app=dict(
+            **get_steps(),
+            total_gb=8000,
+            input_part_gb=2,
+            output_part_gb=4,
+            s3_buckets=get_s3_buckets(40),
+            map_parallelism_multiplier=0.75,
+            reduce_parallelism_multiplier=0.75,
+            merge_factor=1,
+        ),
+    ),
+    JobConfig(
+        # 2243s, https://wandb.ai/raysort/raysort/runs/3i916jv3
+        # 2187s, https://wandb.ai/raysort/raysort/runs/grm4o1p7
+        name="40tb-2gb-i4i4x-s3",
+        cluster=dict(
+            instance_count=40,
+            instance_type=i4i_4xl,
+        ),
+        system=dict(),
+        app=dict(
+            **get_steps(),
+            total_gb=40000,
+            input_part_gb=2,
+            output_part_gb=4,
+            s3_buckets=get_s3_buckets(40),
+            map_parallelism_multiplier=0.75,
+            reduce_parallelism_multiplier=0.75,
+            merge_factor=1,
+        ),
+    ),
+    JobConfig(
+        # 5361s, https://wandb.ai/raysort/raysort/runs/sfycimry
+        name="100tb-2gb-i4i4x-s3",
+        cluster=dict(
+            instance_count=40,
+            instance_type=i4i_4xl,
         ),
         system=dict(),
         app=dict(
             **get_steps(),
             total_gb=100000,
             input_part_gb=2,
-            s3_buckets=get_s3_buckets(),
-            reduce_parallelism_multiplier=1,
-        ),
-    ),
-    # ------------------------------------------------------------
-    #     S3 + i4i.4xl 50-ish nodes
-    # ------------------------------------------------------------
-    JobConfig(
-        # 707s, first run
-        name="10tb-2gb-i4i4x-s3",
-        cluster=dict(
-            instance_count=52,
-            instance_type=i4i_4xl,
-        ),
-        system=dict(),
-        app=dict(
-            **get_steps(),
-            total_gb=10000,
-            input_part_gb=2,
-            s3_buckets=get_s3_buckets(),
-            map_parallelism_multiplier=1,
-            reduce_parallelism_multiplier=1,
+            output_part_gb=4,
+            s3_buckets=get_s3_buckets(40),
+            map_parallelism_multiplier=0.75,
+            reduce_parallelism_multiplier=0.75,
             merge_factor=1,
         ),
     ),
@@ -703,7 +772,6 @@ configs = [
             input_part_gb=2,
             s3_buckets=get_s3_buckets(),
             spilling=SpillingMode.S3,
-            io_parallelism_multiplier=4,
         ),
     ),
     # ------------------------------------------------------------
@@ -726,7 +794,6 @@ configs = [
             total_gb=2000,
             input_part_gb=2,
             s3_buckets=get_s3_buckets(),
-            io_parallelism_multiplier=4,
         ),
     ),
     JobConfig(
@@ -763,7 +830,6 @@ configs = [
             input_part_gb=2,
             s3_buckets=get_s3_buckets(),
             spilling=SpillingMode.S3,
-            io_parallelism_multiplier=4,
         ),
     ),
     # ------------------------------------------------------------
@@ -785,7 +851,6 @@ configs = [
             input_part_gb=2,
             s3_buckets=get_s3_buckets(),
             spilling=SpillingMode.S3,
-            io_parallelism_multiplier=4,
         ),
     ),
     JobConfig(
@@ -804,7 +869,6 @@ configs = [
             input_part_gb=2,
             s3_buckets=get_s3_buckets(),
             spilling=SpillingMode.S3,
-            io_parallelism_multiplier=4,
         ),
     ),
     # ------------------------------------------------------------
@@ -861,28 +925,6 @@ configs = [
             **get_steps(),
             total_gb=1000,
             input_part_gb=1,
-        ),
-    ),
-    # ------------------------------------------------------------
-    #     Ad Hoc Experiments
-    # ------------------------------------------------------------
-    JobConfig(
-        name="i3-simple",
-        cluster=dict(
-            instance_count=10,
-            instance_type=i3_2xl,
-            local=False,
-        ),
-        system=dict(),
-        app=dict(
-            **get_steps(),
-            total_gb=100,
-            input_part_gb=1.25,
-            use_yield=True,
-            reduce_parallelism_multiplier=1,
-            # simple
-            simple_shuffle=True,
-            map_parallelism_multiplier=1,
         ),
     ),
 ]

--- a/raysort/config/common.py
+++ b/raysort/config/common.py
@@ -94,10 +94,12 @@ class SystemConfig:
 class AppConfig:
     _cluster: InitVar[ClusterConfig]
 
-    total_gb: float
-    input_part_gb: float
+    total_gb: InitVar[float]
+    input_part_gb: InitVar[float]
+    output_part_gb: InitVar[Optional[float]] = None
     total_data_size: int = field(init=False)
     input_part_size: int = field(init=False)
+    output_part_size: int = field(init=False)
 
     num_workers: int = field(init=False)
     num_mappers: int = field(init=False)
@@ -111,17 +113,16 @@ class AppConfig:
 
     num_concurrent_rounds: int = 2
     merge_factor: int = 2
-    io_parallelism_multiplier: InitVar[float] = 8.0
     map_parallelism_multiplier: InitVar[float] = 0.5
     reduce_parallelism_multiplier: InitVar[float] = 0.5
-    io_parallelism: int = field(init=False)
     map_parallelism: int = field(init=False)
     merge_parallelism: int = field(init=False)
     reduce_parallelism: int = field(init=False)
 
     io_size: int = 256 * KiB
+    map_io_parallelism: int = 10
+    reduce_io_parallelism: int = 20
     merge_io_parallelism: int = field(init=False)
-    reduce_io_parallelism: int = field(init=False)
 
     shuffle_wait_percentile: float = 0.75
     shuffle_wait_timeout: float = 5.0
@@ -167,14 +168,16 @@ class AppConfig:
     def __post_init__(
         self,
         cluster: ClusterConfig,
-        io_parallelism_multiplier: float,
+        total_gb: float,
+        input_part_gb: float,
+        output_part_gb: Optional[float],
         map_parallelism_multiplier: float,
         reduce_parallelism_multiplier: float,
     ):
         self.is_local_cluster = cluster.local
-        self.total_data_size = int(self.total_gb * GB)
-        self.input_part_size = int(self.input_part_gb * GB)
-        self.io_parallelism = int(io_parallelism_multiplier * cluster.instance_type.cpu)
+        self.total_data_size = int(total_gb * GB)
+        self.input_part_size = int(input_part_gb * GB)
+        self.output_part_size = int((output_part_gb or input_part_gb) * GB)
         self.map_parallelism = int(
             map_parallelism_multiplier * cluster.instance_type.cpu
         )
@@ -209,11 +212,12 @@ class AppConfig:
             math.ceil(self.num_mappers / self.num_workers / self.map_parallelism)
         )
         self.num_mergers_per_worker = self.num_rounds * self.merge_parallelism
-        self.num_reducers_per_worker = self.num_mappers_per_worker
-        self.num_reducers = self.num_reducers_per_worker * self.num_workers
+        self.merge_io_parallelism = self.map_io_parallelism
 
-        self.merge_io_parallelism = self.io_parallelism // self.merge_parallelism
-        self.reduce_io_parallelism = self.io_parallelism // self.reduce_parallelism
+        self.num_reducers = int(math.ceil(self.total_data_size / self.output_part_size))
+        self.num_reducers_per_worker = int(
+            math.ceil(self.num_reducers / self.num_workers)
+        )
 
         self.cloud_storage = bool(self.s3_buckets or self.azure_containers)
 

--- a/raysort/sort_utils.py
+++ b/raysort/sort_utils.py
@@ -197,7 +197,7 @@ def generate_part(
             s3_utils.upload(
                 path,
                 pinfo,
-                max_concurrency=max(1, cfg.io_parallelism // cfg.map_parallelism),
+                max_concurrency=cfg.map_io_parallelism,
             )
         elif cfg.azure_containers:
             azure_utils.upload(path, pinfo)


### PR DESCRIPTION
Also changed: we now set `map_io_parallelism` and `reduce_io_parallelism` independently, instead of basing it on a multiplier of instance CPU.