### PR TITLE
show tasks in w&b

### DIFF
--- a/raysort/tracing_utils.py
+++ b/raysort/tracing_utils.py
@@ -228,13 +228,10 @@ class ProgressTracker:
         import pandas as pd
 
         ret = []
-        counter = 0
         for key, values in self.series.items():
-            counter += 1
             ss = pd.Series(values)
             ret.append(
                 [
-                    counter,
                     key,
                     ss.median(),
                     ss.mean(),
@@ -245,8 +242,8 @@ class ProgressTracker:
                 ]
             )
         df = pd.DataFrame(
-            ret, columns=["index", "task", "median", "mean", "std", "max", "min", "count"]
-        ).set_index("index")
+            ret, columns=["task", "median", "mean", "std", "max", "min", "count"]
+        )
         pd.set_option("display.max_colwidth", None)
         print(self.series.get("output_time"))
         print(df)

--- a/raysort/tracing_utils.py
+++ b/raysort/tracing_utils.py
@@ -228,10 +228,13 @@ class ProgressTracker:
         import pandas as pd
 
         ret = []
+        counter = 0
         for key, values in self.series.items():
+            counter += 1
             ss = pd.Series(values)
             ret.append(
                 [
+                    counter,
                     key,
                     ss.median(),
                     ss.mean(),
@@ -242,8 +245,8 @@ class ProgressTracker:
                 ]
             )
         df = pd.DataFrame(
-            ret, columns=["task", "median", "mean", "std", "max", "min", "count"]
-        ).set_index("task")
+            ret, columns=["index", "task", "median", "mean", "std", "max", "min", "count"]
+        ).set_index("index")
         pd.set_option("display.max_colwidth", None)
         print(self.series.get("output_time"))
         print(df)


### PR DESCRIPTION
Added a new column of indices to use as the index of the table. Previously the "task" column was being used as the index but that made it hidden on the w&b dashboard.

Example: https://wandb.ai/raysort/raysort/runs/2qaecldr?workspace=user-derek-luan